### PR TITLE
Check Unit Type on Actuator Damage

### DIFF
--- a/CBTBehaviorsEnhanced/CBTBehaviorsEnhanced/Patches/MovementPatches.cs
+++ b/CBTBehaviorsEnhanced/CBTBehaviorsEnhanced/Patches/MovementPatches.cs
@@ -5,6 +5,7 @@ using Harmony;
 using IRBTModUtils;
 using IRBTModUtils.Extension;
 using System.Collections.Generic;
+using CBTBehaviorsEnhanced.Helper;
 using us.frostraptor.modUtils;
 
 namespace CBTBehaviorsEnhanced
@@ -109,6 +110,9 @@ namespace CBTBehaviorsEnhanced
                 // Movement - check for damage after a sprint, and if so force a piloting check
                 if (__instance.OwningMech != null && __instance.isSprinting && __instance.OwningMech.ActuatorDamageMalus() != 0)
                 {
+                    // Vehicles, Naval unit & BA do not fall over
+                    if (__instance.OwningMech.IsVehicle() || __instance.OwningMech.IsNaval() ||
+                        __instance.OwningMech.IsTrooper()) return;
                     Mod.Log.Info?.Write($"Actor: {CombatantUtils.Label(__instance.OwningMech)} has actuator damage, forcing piloting check.");
                     float checkMod = __instance.OwningMech.PilotCheckMod(Mod.Config.SkillChecks.ModPerPointOfPiloting);
                     bool sourcePassed = CheckHelper.DidCheckPassThreshold(Mod.Config.Move.FallAfterRunChance, __instance.OwningMech, checkMod, ModText.FT_Fall_After_Run);

--- a/CBTBehaviorsEnhanced/CBTBehaviorsEnhanced/Properties/AssemblyInfo.cs
+++ b/CBTBehaviorsEnhanced/CBTBehaviorsEnhanced/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.15.0")]
-[assembly: AssemblyFileVersion("0.9.15.0")]
+[assembly: AssemblyVersion("0.9.16.0")]
+[assembly: AssemblyFileVersion("0.9.16.0")]


### PR DESCRIPTION
adds a check to ensure a unit with the actuator damage malus is actually allowed to fall over